### PR TITLE
Fix Swift class functions

### DIFF
--- a/src/languages/swift.js
+++ b/src/languages/swift.js
@@ -98,7 +98,7 @@ function(hljs) {
       },
       {
         className: 'class',
-        beginKeywords: 'struct protocol class extension enum',
+        begin: /struct|protocol|extension|class(?!\s+(func|var|let))/,
         keywords: SWIFT_KEYWORDS,
         end: '\\{',
         excludeEnd: true,

--- a/test/markup/swift/functions.expect.txt
+++ b/test/markup/swift/functions.expect.txt
@@ -4,7 +4,10 @@
 }
 
 <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">MyClass</span> </span>{
-  <span class="hljs-function"><span class="hljs-keyword">func</span> <span class="hljs-title">f</span><span class="hljs-params">()</span></span> {
+  <span class="hljs-keyword">class</span> <span class="hljs-function"><span class="hljs-keyword">func</span> <span class="hljs-title">f1</span><span class="hljs-params">()</span></span> {
+    <span class="hljs-keyword">return</span> <span class="hljs-literal">true</span>
+  }
+  <span class="hljs-function"><span class="hljs-keyword">func</span> <span class="hljs-title">f2</span><span class="hljs-params">()</span></span> {
     <span class="hljs-keyword">return</span> <span class="hljs-literal">true</span>
   }
 }

--- a/test/markup/swift/functions.expect.txt
+++ b/test/markup/swift/functions.expect.txt
@@ -4,10 +4,10 @@
 }
 
 <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">MyClass</span> </span>{
-  <span class="hljs-keyword">class</span> <span class="hljs-function"><span class="hljs-keyword">func</span> <span class="hljs-title">f1</span><span class="hljs-params">()</span></span> {
+  <span class="hljs-keyword">class</span> <span class="hljs-function"><span class="hljs-keyword">func</span> <span class="hljs-title">f1</span><span class="hljs-params">()</span></span> -&gt; <span class="hljs-type">Bool</span> {
     <span class="hljs-keyword">return</span> <span class="hljs-literal">true</span>
   }
-  <span class="hljs-function"><span class="hljs-keyword">func</span> <span class="hljs-title">f2</span><span class="hljs-params">()</span></span> {
+  <span class="hljs-function"><span class="hljs-keyword">func</span> <span class="hljs-title">f2</span><span class="hljs-params">()</span></span> -&gt; <span class="hljs-type">Bool</span> {
     <span class="hljs-keyword">return</span> <span class="hljs-literal">true</span>
   }
 }

--- a/test/markup/swift/functions.txt
+++ b/test/markup/swift/functions.txt
@@ -4,7 +4,10 @@ protocol Protocol {
 }
 
 class MyClass {
-  func f() {
+  class func f1() {
+    return true
+  }
+  func f2() {
     return true
   }
 }

--- a/test/markup/swift/functions.txt
+++ b/test/markup/swift/functions.txt
@@ -4,10 +4,10 @@ protocol Protocol {
 }
 
 class MyClass {
-  class func f1() {
+  class func f1() -> Bool {
     return true
   }
-  func f2() {
+  func f2() -> Bool {
     return true
   }
 }


### PR DESCRIPTION
`class` keyword only triggers a class when not followed by `func`, `var` or `let`.